### PR TITLE
Added PHP 8.0 support #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,28 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.3
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         }
     },
     "require": {
-        "php": "^7.1",
-        "laminas/laminas-servicemanager": "^3.4",
-        "laminas/laminas-view": "^2.11.1",
+        "php": "^7.3 || ~8.0.0",
+        "laminas/laminas-servicemanager": "^3.4.1",
+        "laminas/laminas-view": "^2.11.4",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-helpers": "^5.0",
         "mezzio/mezzio-router": "^3.0",
@@ -40,8 +40,9 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^7.0.2"
+        "malukenho/docheader": "^0.1.8",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="Mezzio laminas-view PhpRenderer Tests">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Mezzio laminas-view PhpRenderer Tests">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -28,7 +28,7 @@ class ConfigProviderTest extends TestCase
     public function testInvocationReturnsArray() : array
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
 
         return $config;
     }
@@ -40,6 +40,6 @@ class ConfigProviderTest extends TestCase
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertArrayHasKey('templates', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -45,7 +45,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        $this->assertContains('Exception', $exception);
+        $this->assertStringContainsString('Exception', $exception);
         $this->assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -15,16 +15,19 @@ use Laminas\View\HelperPluginManager;
 use Mezzio\LaminasView\HelperPluginManagerFactory;
 use MezzioTest\LaminasView\TestAsset\TestHelper;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 
 class HelperPluginManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ServiceManager|ProphecyInterface
      */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ServiceManager::class);
     }

--- a/test/LaminasViewRendererFactoryTest.php
+++ b/test/LaminasViewRendererFactoryTest.php
@@ -23,6 +23,7 @@ use Mezzio\LaminasView\ServerUrlHelper;
 use Mezzio\LaminasView\UrlHelper;
 use Mezzio\Template\TemplatePath;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
@@ -34,12 +35,14 @@ use const DIRECTORY_SEPARATOR;
 
 class LaminasViewRendererFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ContainerInterface|ProphecyInterface
     */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }
@@ -152,7 +155,7 @@ class LaminasViewRendererFactoryTest extends TestCase
     public function testUnconfiguredLaminasViewInstanceContainsNoPaths(LaminasViewRenderer $view)
     {
         $paths = $view->getPaths();
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertEmpty($paths);
     }
 

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -13,17 +13,20 @@ namespace MezzioTest\LaminasView;
 use Mezzio\Helper\ServerUrlHelper as BaseHelper;
 use Mezzio\LaminasView\ServerUrlHelper;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Message\UriInterface;
 
 class ServerUrlHelperTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var BaseHelper|ProphecyInterface
      */
     private $baseHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->baseHelper = $this->prophesize(BaseHelper::class);
     }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -13,16 +13,19 @@ namespace MezzioTest\LaminasView;
 use Mezzio\Helper\UrlHelper as BaseHelper;
 use Mezzio\LaminasView\UrlHelper;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 
 class UrlHelperTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var BaseHelper|ProphecyInterface
      */
     private $baseHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->baseHelper = $this->prophesize(BaseHelper::class);
     }


### PR DESCRIPTION

Q | A
-- | --
New Feature | yes

Summary
To be prepared for the december release of PHP 8.0, this repository has some additional TODOs to be tested against the new major version.

In order to make this repository compatible, one has to follow these steps:

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x]  Modify composer.json to drop support for PHP less than 7.3
- [x]  Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
- [x]  Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [x]  Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x]  Modify source code in case there are incompatibilities with PHP 8.0

closes #4 