### PR TITLE
Update to laminas-coding-standard v2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.4",
         "malukenho/docheader": "^0.1.5",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e30348d259874c9bd639076460a0ccd",
+    "content-hash": "bf3091a35eb6ba2cb6d909e8748968e2",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1030,6 +1030,76 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -1100,31 +1170,37 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
                 "shasum": ""
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1138,7 +1214,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-10-26T07:33:05+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -1697,6 +1779,59 @@
                 "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
             },
             "time": "2020-07-09T08:33:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3084,64 +3219,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3154,7 +3323,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -3164,7 +3333,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -4021,6 +4190,61 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -12,27 +12,28 @@ namespace Mezzio\LaminasView;
 
 use Laminas\View\HelperPluginManager;
 use Mezzio\Template\TemplateRendererInterface;
+use Zend\Expressive\ZendView\ZendViewRenderer;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
-            'templates' => $this->getTemplates(),
+            'templates'    => $this->getTemplates(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 TemplateRendererInterface::class => LaminasViewRenderer::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Template\TemplateRendererInterface::class => TemplateRendererInterface::class,
-                \Zend\View\HelperPluginManager::class => HelperPluginManager::class,
-                \Zend\Expressive\ZendView\ZendViewRenderer::class => LaminasViewRenderer::class,
+                \Zend\View\HelperPluginManager::class                      => HelperPluginManager::class,
+                ZendViewRenderer::class                                    => LaminasViewRenderer::class,
             ],
             'factories' => [
                 HelperPluginManager::class => HelperPluginManagerFactory::class,
@@ -41,12 +42,12 @@ class ConfigProvider
         ];
     }
 
-    public function getTemplates() : array
+    public function getTemplates(): array
     {
         return [
             'extension' => 'phtml',
-            'layout' => 'layout::default',
-            'paths' => [],
+            'layout'    => 'layout::default',
+            'paths'     => [],
         ];
     }
 }

--- a/src/HelperPluginManagerFactory.php
+++ b/src/HelperPluginManagerFactory.php
@@ -16,7 +16,7 @@ use Psr\Container\ContainerInterface;
 
 class HelperPluginManagerFactory
 {
-    public function __invoke(ContainerInterface $container) : HelperPluginManager
+    public function __invoke(ContainerInterface $container): HelperPluginManager
     {
         $manager = new HelperPluginManager($container);
 

--- a/src/LaminasViewRenderer.php
+++ b/src/LaminasViewRenderer.php
@@ -44,19 +44,13 @@ class LaminasViewRenderer implements TemplateRendererInterface
     use ArrayParametersTrait;
     use DefaultParamsTrait;
 
-    /**
-     * @var ViewModel
-     */
+    /** @var ViewModel */
     private $layout;
 
-    /**
-     * @var RendererInterface
-     */
+    /** @var RendererInterface */
     private $renderer;
 
-    /**
-     * @var NamespacedPathStackResolver
-     */
+    /** @var NamespacedPathStackResolver */
     private $resolver;
 
     /**
@@ -74,12 +68,11 @@ class LaminasViewRenderer implements TemplateRendererInterface
      * omitting the layout indicates no layout should be used by default when
      * rendering.
      *
-     * @param null|RendererInterface $renderer
      * @param null|string|ModelInterface $layout
      * @param null|string $defaultSuffix The default template file suffix, if any
-     * @throws Exception\InvalidArgumentException for invalid $layout types
+     * @throws Exception\InvalidArgumentException For invalid $layout types.
      */
-    public function __construct(RendererInterface $renderer = null, $layout = null, string $defaultSuffix = null)
+    public function __construct(?RendererInterface $renderer = null, $layout = null, ?string $defaultSuffix = null)
     {
         if (null === $renderer) {
             $renderer = $this->createRenderer();
@@ -105,7 +98,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
             throw new Exception\InvalidArgumentException(sprintf(
                 'Layout must be a string layout template name or a %s instance; received %s',
                 ModelInterface::class,
-                (is_object($layout) ? get_class($layout) : gettype($layout))
+                is_object($layout) ? get_class($layout) : gettype($layout)
             ));
         }
 
@@ -114,7 +107,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
         if (null !== $defaultSuffix) {
             $this->resolver->setDefaultSuffix($defaultSuffix);
         }
-        $this->layout   = $layout;
+        $this->layout = $layout;
     }
 
     /**
@@ -128,11 +121,10 @@ class LaminasViewRenderer implements TemplateRendererInterface
      * - a Laminas\View\Model\ModelInterface instance
      *
      * Layouts specified with $params take precedence over layouts passed to
-     * the constructor.
      *
      * @param array|ModelInterface|object $params
      */
-    public function render(string $name, $params = []) : string
+    public function render(string $name, $params = []): string
     {
         $viewModel = $params instanceof ModelInterface
             ? $this->mergeViewModel($name, $params)
@@ -149,7 +141,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
     /**
      * Add a path for templates.
      */
-    public function addPath(string $path, string $namespace = null) : void
+    public function addPath(string $path, ?string $namespace = null): void
     {
         $this->resolver->addPath($path, $namespace);
     }
@@ -159,12 +151,13 @@ class LaminasViewRenderer implements TemplateRendererInterface
      *
      * @return TemplatePath[]
      */
-    public function getPaths() : array
+    public function getPaths(): array
     {
         $paths = [];
 
         foreach ($this->resolver->getPaths() as $namespace => $namespacedPaths) {
-            if ($namespace === NamespacedPathStackResolver::DEFAULT_NAMESPACE
+            if (
+                $namespace === NamespacedPathStackResolver::DEFAULT_NAMESPACE
                 || empty($namespace)
                 || is_int($namespace)
             ) {
@@ -197,13 +190,13 @@ class LaminasViewRenderer implements TemplateRendererInterface
     /**
      * Do a recursive, depth-first rendering of a view model.
      *
-     * @throws Exception\RenderingException if it encounters a terminal child.
+     * @throws Exception\RenderingException If it encounters a terminal child.
      */
     private function renderModel(
         ModelInterface $model,
         RendererInterface $renderer,
-        ModelInterface $root = null
-    ) : string {
+        ?ModelInterface $root = null
+    ): string {
         if (! $root) {
             $root = $model;
         }
@@ -218,7 +211,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
                 continue;
             }
 
-            $child  = $this->mergeViewModel($child->getTemplate(), $child);
+            $child = $this->mergeViewModel($child->getTemplate(), $child);
 
             if ($child !== $root) {
                 $viewModelHelper = $renderer->plugin(Helper\ViewModel::class);
@@ -242,7 +235,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
     /**
      * Returns a PhpRenderer object
      */
-    private function createRenderer() : PhpRenderer
+    private function createRenderer(): PhpRenderer
     {
         $renderer = new PhpRenderer();
         $renderer->setResolver($this->getDefaultResolver());
@@ -252,7 +245,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
     /**
      * Get the default resolver
      */
-    private function getDefaultResolver() : AggregateResolver
+    private function getDefaultResolver(): AggregateResolver
     {
         $resolver = new AggregateResolver();
         $this->injectNamespacedResolver($resolver);
@@ -264,12 +257,12 @@ class LaminasViewRenderer implements TemplateRendererInterface
      *
      * A priority of 0 is used, to ensure it is the last queried.
      */
-    private function injectNamespacedResolver(AggregateResolver $aggregate) : void
+    private function injectNamespacedResolver(AggregateResolver $aggregate): void
     {
         $aggregate->attach(new NamespacedPathStackResolver(), 0);
     }
 
-    private function hasNamespacedResolver(AggregateResolver $aggregate) : bool
+    private function hasNamespacedResolver(AggregateResolver $aggregate): bool
     {
         foreach ($aggregate as $resolver) {
             if ($resolver instanceof NamespacedPathStackResolver) {
@@ -280,7 +273,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
         return false;
     }
 
-    private function getNamespacedResolver(AggregateResolver $aggregate) : ?NamespacedPathStackResolver
+    private function getNamespacedResolver(AggregateResolver $aggregate): ?NamespacedPathStackResolver
     {
         foreach ($aggregate as $resolver) {
             if ($resolver instanceof NamespacedPathStackResolver) {
@@ -296,7 +289,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
      *
      * @param string $name Template name.
      */
-    private function mergeViewModel(string $name, ModelInterface $model) : ModelInterface
+    private function mergeViewModel(string $name, ModelInterface $model): ModelInterface
     {
         $params = $this->mergeParams(
             $name,
@@ -325,7 +318,7 @@ class LaminasViewRenderer implements TemplateRendererInterface
      * otherwise, a view model representing the layout, with the provided
      * view model as a child, is returned.
      */
-    private function prepareLayout(ModelInterface $viewModel) : ModelInterface
+    private function prepareLayout(ModelInterface $viewModel): ModelInterface
     {
         $providedLayout = $viewModel->getVariable('layout', null);
         if (is_string($providedLayout) && ! empty($providedLayout)) {

--- a/src/LaminasViewRendererFactory.php
+++ b/src/LaminasViewRendererFactory.php
@@ -56,11 +56,10 @@ use function sprintf;
  */
 class LaminasViewRendererFactory
 {
-    public function __invoke(ContainerInterface $container) : LaminasViewRenderer
+    public function __invoke(ContainerInterface $container): LaminasViewRenderer
     {
-        $config   = $container->has('config') ? $container->get('config') : [];
-        $config   = $config['templates'] ?? [];
-
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['templates'] ?? [];
 
         // Configuration
         $resolver = new Resolver\AggregateResolver();
@@ -104,17 +103,18 @@ class LaminasViewRendererFactory
      *
      * In each case, injects with the custom url/serverurl implementations.
      *
-     * @throws Exception\InvalidContainerException if the $container argument
+     * @throws Exception\InvalidContainerException If the $container argument
      *     does not implement InteropContainerInterface.
      * @throws Exception\MissingHelperException
      */
-    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container) : void
+    private function injectHelpers(PhpRenderer $renderer, ContainerInterface $container): void
     {
         $helpers = $this->retrieveHelperManager($container);
         $helpers->setAlias('url', BaseUrlHelper::class);
         $helpers->setAlias('Url', BaseUrlHelper::class);
         $helpers->setFactory(BaseUrlHelper::class, function () use ($container) {
-            if (! $container->has(BaseUrlHelper::class)
+            if (
+                ! $container->has(BaseUrlHelper::class)
                 && ! $container->has(\Zend\Expressive\Helper\UrlHelper::class)
             ) {
                 throw new Exception\MissingHelperException(sprintf(
@@ -133,7 +133,8 @@ class LaminasViewRendererFactory
         $helpers->setAlias('serverUrl', BaseServerUrlHelper::class);
         $helpers->setAlias('ServerUrl', BaseServerUrlHelper::class);
         $helpers->setFactory(BaseServerUrlHelper::class, function () use ($container) {
-            if (! $container->has(BaseServerUrlHelper::class)
+            if (
+                ! $container->has(BaseServerUrlHelper::class)
                 && ! $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)
             ) {
                 throw new Exception\MissingHelperException(sprintf(
@@ -152,10 +153,10 @@ class LaminasViewRendererFactory
     }
 
     /**
-     * @throws Exception\InvalidContainerException if the $container argument
+     * @throws Exception\InvalidContainerException If the $container argument
      *     does not implement InteropContainerInterface.
      */
-    private function retrieveHelperManager(ContainerInterface $container) : HelperPluginManager
+    private function retrieveHelperManager(ContainerInterface $container): HelperPluginManager
     {
         if ($container->has(HelperPluginManager::class)) {
             return $container->get(HelperPluginManager::class);

--- a/src/NamespacedPathStackResolver.php
+++ b/src/NamespacedPathStackResolver.php
@@ -13,6 +13,7 @@ namespace Mezzio\LaminasView;
 use Laminas\View\Exception as ViewException;
 use Laminas\View\Renderer\RendererInterface;
 use Laminas\View\Resolver\TemplatePathStack;
+use Laminas\View\Stream;
 use SplFileInfo;
 use SplStack;
 use Traversable;
@@ -52,9 +53,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
 {
     public const DEFAULT_NAMESPACE = '__DEFAULT__';
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $paths = [];
 
     /**
@@ -63,12 +62,12 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * Overrides parent constructor to allow specifying paths as an associative
      * array.
      */
-    public function __construct(iterable $options = null)
+    public function __construct(?iterable $options = null)
     {
         $this->useViewStream = (bool) ini_get('short_open_tag');
         if ($this->useViewStream) {
             if (! in_array('laminas.view', stream_get_wrappers())) {
-                stream_wrapper_register('laminas.view', 'Laminas\View\Stream');
+                stream_wrapper_register('laminas.view', Stream::class);
             }
         }
 
@@ -81,10 +80,10 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * Add a path to the stack with the given namespace.
      *
      * @param string $path
-     * @throws ViewException\InvalidArgumentException for an invalid path
-     * @throws ViewException\InvalidArgumentException for an invalid namespace
+     * @throws ViewException\InvalidArgumentException For an invalid path.
+     * @throws ViewException\InvalidArgumentException For an invalid namespace.
      */
-    public function addPath($path, ?string $namespace = self::DEFAULT_NAMESPACE) : void
+    public function addPath($path, ?string $namespace = self::DEFAULT_NAMESPACE): void
     {
         if (! is_string($path)) {
             throw new ViewException\InvalidArgumentException(sprintf(
@@ -113,7 +112,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
     /**
      * Add many paths to the stack at once.
      */
-    public function addPaths(array $paths) : void
+    public function addPaths(array $paths): void
     {
         foreach ($paths as $namespace => $path) {
             if (! is_string($namespace)) {
@@ -128,9 +127,9 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * Overwrite all existing paths with the provided paths.
      *
      * @param  SplStack|array $paths
-     * @throws ViewException\InvalidArgumentException for invalid path types.
+     * @throws ViewException\InvalidArgumentException For invalid path types.
      */
-    public function setPaths($paths) : void
+    public function setPaths($paths): void
     {
         if ($paths instanceof Traversable) {
             $paths = iterator_to_array($paths);
@@ -139,7 +138,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
         if (! is_array($paths)) {
             throw new ViewException\InvalidArgumentException(sprintf(
                 'Invalid paths provided; must be an array or Traversable, received %s',
-                (is_object($paths) ? get_class($paths) : gettype($paths))
+                is_object($paths) ? get_class($paths) : gettype($paths)
             ));
         }
 
@@ -150,7 +149,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
     /**
      * Clear all paths.
      */
-    public function clearPaths() : void
+    public function clearPaths(): void
     {
         $this->paths = [];
     }
@@ -161,7 +160,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
      * @param string $name
      * @throws ViewException\DomainException
      */
-    public function resolve($name, RendererInterface $renderer = null) : ?string
+    public function resolve($name, ?RendererInterface $renderer = null): ?string
     {
         $namespace = self::DEFAULT_NAMESPACE;
         $template  = $name;
@@ -185,7 +184,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
 
         // Ensure we have the expected file extension
         $defaultSuffix = $this->getDefaultSuffix();
-        if (pathinfo($template, PATHINFO_EXTENSION) == '') {
+        if (pathinfo($template, PATHINFO_EXTENSION) === '') {
             $template .= '.' . $defaultSuffix;
         }
 
@@ -209,7 +208,7 @@ class NamespacedPathStackResolver extends TemplatePathStack
      *
      * @return null|string String path on success; null on failure
      */
-    private function getPathFromNamespace(string $template, string $namespace) : ?string
+    private function getPathFromNamespace(string $template, string $namespace): ?string
     {
         if (! array_key_exists($namespace, $this->paths)) {
             return null;

--- a/src/NamespacedPathStackResolverFactory.php
+++ b/src/NamespacedPathStackResolverFactory.php
@@ -14,10 +14,10 @@ use Psr\Container\ContainerInterface;
 
 class NamespacedPathStackResolverFactory
 {
-    public function __invoke(ContainerInterface $container) : NamespacedPathStackResolver
+    public function __invoke(ContainerInterface $container): NamespacedPathStackResolver
     {
-        $config   = $container->has('config') ? $container->get('config') : [];
-        $config   = $config['templates'] ?? [];
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['templates'] ?? [];
 
         $resolver = new NamespacedPathStackResolver();
         if (! empty($config['default_suffix'])) {

--- a/src/ServerUrlHelper.php
+++ b/src/ServerUrlHelper.php
@@ -19,9 +19,7 @@ use Psr\Http\Message\UriInterface;
  */
 class ServerUrlHelper extends AbstractHelper
 {
-    /**
-     * @var BaseHelper
-     */
+    /** @var BaseHelper */
     private $helper;
 
     public function __construct(BaseHelper $helper)
@@ -34,7 +32,7 @@ class ServerUrlHelper extends AbstractHelper
      *
      * Proxies to `Mezzio\Helper\ServerUrlHelper::generate()`.
      */
-    public function __invoke(string $path = null) : string
+    public function __invoke(?string $path = null): string
     {
         return $this->helper->generate($path);
     }
@@ -42,7 +40,7 @@ class ServerUrlHelper extends AbstractHelper
     /**
      * Proxies to `Mezzio\Helper\ServerUrlHelper::setUri()`
      */
-    public function setUri(UriInterface $uri) : void
+    public function setUri(UriInterface $uri): void
     {
         $this->helper->setUri($uri);
     }

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -15,14 +15,9 @@ use Mezzio\Helper\UrlHelper as BaseHelper;
 
 class UrlHelper extends AbstractHelper
 {
-    /**
-     * @var BaseHelper
-     */
+    /** @var BaseHelper */
     private $helper;
 
-    /**
-     * @param BaseHelper $helper
-     */
     public function __construct(BaseHelper $helper)
     {
         $this->helper = $helper;
@@ -38,10 +33,10 @@ class UrlHelper extends AbstractHelper
      * @return string
      */
     public function __invoke(
-        string $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        string $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
     ) {
         return $this->helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,9 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var ConfigProvider
-     */
+    /** @var ConfigProvider */
     private $provider;
 
     protected function setUp(): void
@@ -25,7 +23,7 @@ class ConfigProviderTest extends TestCase
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         $this->assertIsArray($config);
@@ -36,7 +34,7 @@ class ConfigProviderTest extends TestCase
     /**
      * @depends testInvocationReturnsArray
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertArrayHasKey('templates', $config);

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -23,12 +23,12 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function testExceptionInterfaceExtendsTemplateExceptionInterface() : void
+    public function testExceptionInterfaceExtendsTemplateExceptionInterface(): void
     {
         $this->assertTrue(is_a(ExceptionInterface::class, TemplateExceptionInterface::class, true));
     }
 
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -43,7 +43,7 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         $this->assertStringContainsString('Exception', $exception);
         $this->assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/HelperPluginManagerFactoryTest.php
+++ b/test/HelperPluginManagerFactoryTest.php
@@ -42,7 +42,9 @@ class HelperPluginManagerFactoryTest extends TestCase
         return $factory($this->container);
     }
 
-    /** @param array<array-key, mixed> */
+    /**
+     * @psalm-param array<array-key, mixed> $configuration
+     */
     private function containerWillHaveConfiguration(array $configuration): void
     {
         $this->container

--- a/test/LaminasViewRendererFactoryTest.php
+++ b/test/LaminasViewRendererFactoryTest.php
@@ -32,6 +32,7 @@ use Psr\Container\ContainerInterface as PsrContainerInterface;
 use ReflectionProperty;
 
 use function sprintf;
+use function var_export;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -39,9 +40,7 @@ class LaminasViewRendererFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface|ProphecyInterface
-    */
+    /** @var ContainerInterface|ProphecyInterface */
     private $container;
 
     protected function setUp(): void
@@ -49,24 +48,30 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
     }
 
-    public function getConfigurationPaths()
+    /**
+     * @psalm-return array<array-key, string|string[]>
+     */
+    public function getConfigurationPaths(): array
     {
         return [
             'foo' => __DIR__ . '/TestAsset/bar',
-            1 => __DIR__ . '/TestAsset/one',
+            1     => __DIR__ . '/TestAsset/one',
             'bar' => [
                 __DIR__ . '/TestAsset/baz',
                 __DIR__ . '/TestAsset/bat',
             ],
-            0 => [
+            0     => [
                 __DIR__ . '/TestAsset/two',
                 __DIR__ . '/TestAsset/three',
             ],
         ];
     }
 
-    public function assertPathsHasNamespace($namespace, array $paths, $message = null)
-    {
+    public function assertPathsHasNamespace(
+        ?string $namespace,
+        array $paths,
+        ?string $message = null
+    ): void {
         $message = $message ?: sprintf('Paths do not contain namespace %s', $namespace ?: 'null');
 
         $found = false;
@@ -80,8 +85,12 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->assertTrue($found, $message);
     }
 
-    public function assertPathNamespaceCount($expected, $namespace, array $paths, $message = null)
-    {
+    public function assertPathNamespaceCount(
+        int $expected,
+        ?string $namespace,
+        array $paths,
+        ?string $message = null
+    ): void {
         $message = $message ?: sprintf('Did not find %d paths with namespace %s', $expected, $namespace ?: 'null');
 
         $count = 0;
@@ -94,8 +103,15 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->assertSame($expected, $count, $message);
     }
 
-    public function assertPathNamespaceContains($expected, $namespace, array $paths, $message = null)
-    {
+    /**
+     * @param mixed $expected
+     */
+    public function assertPathNamespaceContains(
+        $expected,
+        ?string $namespace,
+        array $paths,
+        ?string $message = null
+    ): void {
         $message = $message ?: sprintf('Did not find path %s in namespace %s', $expected, $namespace ?: null);
 
         $found = [];
@@ -108,6 +124,9 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->assertContains($expected, $found, $message);
     }
 
+    /**
+     * @return mixed
+     */
     public function fetchPhpRenderer(LaminasViewRenderer $view)
     {
         $r = new ReflectionProperty($view, 'renderer');
@@ -115,7 +134,10 @@ class LaminasViewRendererFactoryTest extends TestCase
         return $r->getValue($view);
     }
 
-    public function injectContainerService($name, $service)
+    /**
+     * @param mixed $service Service to return from container
+     */
+    public function injectContainerService(string $name, $service): void
     {
         $this->container->has($name)->willReturn(true);
         $this->container->get($name)->willReturn(
@@ -135,7 +157,7 @@ class LaminasViewRendererFactoryTest extends TestCase
         );
     }
 
-    public function testCallingFactoryWithNoConfigReturnsLaminasViewInstance()
+    public function testCallingFactoryWithNoConfigReturnsLaminasViewInstance(): LaminasViewRenderer
     {
         $this->container->has('config')->willReturn(false);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
@@ -151,8 +173,6 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     /**
      * @depends testCallingFactoryWithNoConfigReturnsLaminasViewInstance
-     *
-     * @param LaminasViewRenderer $view
      */
     public function testUnconfiguredLaminasViewInstanceContainsNoPaths(LaminasViewRenderer $view)
     {
@@ -176,7 +196,7 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container->has(\Zend\View\Renderer\PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $r = new ReflectionProperty($view, 'layout');
         $r->setAccessible(true);
@@ -200,7 +220,7 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container->has(\Zend\View\Renderer\PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $paths = $view->getPaths();
         $this->assertPathsHasNamespace('foo', $paths);
@@ -244,7 +264,7 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container->has(\Zend\View\Renderer\PhpRenderer::class)->willReturn(false);
         $this->injectBaseHelpers();
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $r = new ReflectionProperty($view, 'renderer');
         $r->setAccessible(true);
@@ -280,11 +300,11 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container->has(\Zend\View\Renderer\PhpRenderer::class)->willReturn(false);
 
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $r = new ReflectionProperty($view, 'resolver');
         $r->setAccessible(true);
-        $resolver  = $r->getValue($view);
+        $resolver = $r->getValue($view);
 
         $this->assertInstanceOf(
             NamespacedPathStackResolver::class,
@@ -310,11 +330,11 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->container->has(\Zend\View\Renderer\PhpRenderer::class)->willReturn(false);
 
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $r = new ReflectionProperty($view, 'resolver');
         $r->setAccessible(true);
-        $resolver  = $r->getValue($view);
+        $resolver = $r->getValue($view);
 
         $this->assertInstanceOf(
             NamespacedPathStackResolver::class,
@@ -345,7 +365,7 @@ class LaminasViewRendererFactoryTest extends TestCase
         $this->assertInstanceOf(ServerUrlHelper::class, $helpers->get('serverurl'));
     }
 
-    public function testWillUseHelperManagerFromContainer()
+    public function testWillUseHelperManagerFromContainer(): HelperPluginManager
     {
         $this->container->has('config')->willReturn(false);
         $this->container->has(PhpRenderer::class)->willReturn(false);
@@ -366,8 +386,6 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     /**
      * @depends testWillUseHelperManagerFromContainer
-     *
-     * @param HelperPluginManager $helpers
      */
     public function testInjectsCustomHelpersIntoHelperManagerFromContainer(HelperPluginManager $helpers)
     {
@@ -379,14 +397,14 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testWillUseRendererFromContainer()
     {
-        $engine = new PhpRenderer;
+        $engine = new PhpRenderer();
         $this->container->has('config')->willReturn(false);
         $this->container->has(HelperPluginManager::class)->willReturn(false);
         $this->container->has(\Zend\View\HelperPluginManager::class)->willReturn(false);
         $this->injectContainerService(PhpRenderer::class, $engine);
 
         $factory = new LaminasViewRendererFactory();
-        $view = $factory($this->container->reveal());
+        $view    = $factory($this->container->reveal());
 
         $composed = $this->fetchPhpRenderer($view);
         $this->assertSame($engine, $composed);

--- a/test/LaminasViewRendererTest.php
+++ b/test/LaminasViewRendererTest.php
@@ -19,7 +19,6 @@ use Mezzio\Template\Exception\InvalidArgumentException;
 use Mezzio\Template\TemplatePath;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\TestCase;
-
 use ReflectionProperty;
 
 use function file_get_contents;
@@ -30,55 +29,59 @@ use function uniqid;
 use function var_export;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_EOL;
 
 class LaminasViewRendererTest extends TestCase
 {
-    /**
-     * @var TemplatePathStack
-    */
+    /** @var TemplatePathStack */
     private $resolver;
 
-    /**
-     * @var PhpRenderer
-     */
+    /** @var PhpRenderer */
     private $render;
 
     protected function setUp(): void
     {
         $this->resolver = new TemplatePathStack();
-        $this->render = new PhpRenderer();
+        $this->render   = new PhpRenderer();
         $this->render->setResolver($this->resolver);
     }
 
-    public function assertTemplatePath($path, TemplatePath $templatePath, $message = null)
+    public function assertTemplatePath(string $path, TemplatePath $templatePath, ?string $message = null): void
     {
         $message = $message ?: sprintf('Failed to assert TemplatePath contained path %s', $path);
         $this->assertEquals($path, $templatePath->getPath(), $message);
     }
 
-    public function assertTemplatePathString($path, TemplatePath $templatePath, $message = null)
+    public function assertTemplatePathString(string $path, TemplatePath $templatePath, ?string $message = null): void
     {
         $message = $message ?: sprintf('Failed to assert TemplatePath casts to string path %s', $path);
         $this->assertEquals($path, (string) $templatePath, $message);
     }
 
-    public function assertTemplatePathNamespace($namespace, TemplatePath $templatePath, $message = null)
-    {
+    public function assertTemplatePathNamespace(
+        string $namespace,
+        TemplatePath $templatePath,
+        ?string $message = null
+    ): void {
         $message = $message
             ?: sprintf('Failed to assert TemplatePath namespace matched %s', var_export($namespace, true));
         $this->assertEquals($namespace, $templatePath->getNamespace(), $message);
     }
 
-    public function assertEmptyTemplatePathNamespace(TemplatePath $templatePath, $message = null)
+    public function assertEmptyTemplatePathNamespace(TemplatePath $templatePath, ?string $message = null): void
     {
         $message = $message ?: 'Failed to assert TemplatePath namespace was empty';
         $this->assertEmpty($templatePath->getNamespace(), $message);
     }
 
-    public function assertEqualTemplatePath(TemplatePath $expected, TemplatePath $received, $message = null)
-    {
+    public function assertEqualTemplatePath(
+        TemplatePath $expected,
+        TemplatePath $received,
+        ?string $message = null
+    ): void {
         $message = $message ?: 'Failed to assert TemplatePaths are equal';
-        if ($expected->getPath() !== $received->getPath()
+        if (
+            $expected->getPath() !== $received->getPath()
             || $expected->getNamespace() !== $received->getNamespace()
         ) {
             $this->fail($message);
@@ -143,8 +146,8 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name]);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -167,7 +170,6 @@ class LaminasViewRendererTest extends TestCase
 
     /**
      * @dataProvider invalidParameterValues
-     *
      * @param mixed $params
      */
     public function testRenderRaisesExceptionForInvalidParameterTypes($params): void
@@ -182,7 +184,7 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $result = $renderer->render('laminasview-null', null);
+        $result  = $renderer->render('laminasview-null', null);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview-null.phtml');
         $this->assertEquals($content, $result);
     }
@@ -203,9 +205,6 @@ class LaminasViewRendererTest extends TestCase
 
     /**
      * @dataProvider objectParameterValues
-     *
-     * @param object $params
-     * @param string $search
      */
     public function testCanRenderWithParameterObjects(object $params, string $search): void
     {
@@ -225,8 +224,8 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer(null, 'laminasview-layout');
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name]);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -241,7 +240,7 @@ class LaminasViewRendererTest extends TestCase
         $title = uniqid('LaminasViewTitle', true);
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'title', $title);
 
-        $name = uniqid('LaminasViewName', true);
+        $name   = uniqid('LaminasViewName', true);
         $result = $renderer->render('laminasview', ['name' => $name]);
 
         $this->assertStringContainsString($title, $result);
@@ -260,7 +259,7 @@ class LaminasViewRendererTest extends TestCase
         $title = uniqid('LaminasViewTitle', true);
         $renderer->addDefaultParam('laminasview', 'title', $title);
 
-        $name = uniqid('LaminasViewName', true);
+        $name   = uniqid('LaminasViewName', true);
         $result = $renderer->render('laminasview', ['name' => $name]);
 
         $this->assertStringNotContainsString($title, $result);
@@ -277,7 +276,7 @@ class LaminasViewRendererTest extends TestCase
         $renderer = new LaminasViewRenderer(null, 'laminasview-layout-variable');
         $renderer->addPath(__DIR__ . '/TestAsset');
         $title = uniqid('LaminasViewTitle', true);
-        $name = uniqid('LaminasViewName', true);
+        $name  = uniqid('LaminasViewName', true);
         $renderer->addDefaultParam('laminasview-layout-variable', 'title', $title);
         $result = $renderer->render('laminasview', ['name' => $name]);
         $this->assertStringContainsString($title, $result);
@@ -285,9 +284,9 @@ class LaminasViewRendererTest extends TestCase
 
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
-        $layout = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
-        $layout = str_replace('<?= $this->title ?>', $title, $layout);
-        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $layout  = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
+        $layout  = str_replace('<?= $this->title ?>', $title, $layout);
+        $layout  = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
         $this->assertStringContainsString($layout, $result);
 
         $expected = sprintf('<title>Layout Page: %s</title>', $title);
@@ -299,8 +298,8 @@ class LaminasViewRendererTest extends TestCase
         $renderer = new LaminasViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');
         $titleToBeOverriden = uniqid('LaminasViewTitleToBeOverriden', true);
-        $title = uniqid('LaminasViewTitle', true);
-        $name = uniqid('LaminasViewName', true);
+        $title              = uniqid('LaminasViewTitle', true);
+        $name               = uniqid('LaminasViewName', true);
         $renderer->addDefaultParam('laminasview-layout-variable', 'title', $titleToBeOverriden);
 
         $layout = new ViewModel(['title' => $title]);
@@ -311,9 +310,9 @@ class LaminasViewRendererTest extends TestCase
 
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
-        $layout = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
-        $layout = str_replace('<?= $this->title ?>', $title, $layout);
-        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $layout  = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
+        $layout  = str_replace('<?= $this->title ?>', $title, $layout);
+        $layout  = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
         $this->assertStringContainsString($layout, $result);
 
         $expected = sprintf('<title>Layout Page: %s</title>', $title);
@@ -325,7 +324,7 @@ class LaminasViewRendererTest extends TestCase
         $renderer = new LaminasViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');
         $title = uniqid('LaminasViewTitle', true);
-        $name = uniqid('LaminasViewName', true);
+        $name  = uniqid('LaminasViewName', true);
         $renderer->addDefaultParam('laminasview-layout-variable', 'title', $title);
 
         $layout = new ViewModel();
@@ -336,9 +335,9 @@ class LaminasViewRendererTest extends TestCase
 
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
-        $layout = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
-        $layout = str_replace('<?= $this->title ?>', $title, $layout);
-        $layout = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
+        $layout  = file_get_contents(__DIR__ . '/TestAsset/laminasview-layout-variable.phtml');
+        $layout  = str_replace('<?= $this->title ?>', $title, $layout);
+        $layout  = str_replace('<?= $this->content ?>' . PHP_EOL, $content, $layout);
         $this->assertStringContainsString($layout, $result);
 
         $expected = sprintf('<title>Layout Page: %s</title>', $title);
@@ -352,8 +351,8 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer(null);
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name, 'layout' => 'laminasview-layout' ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name, 'layout' => 'laminasview-layout']);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -369,8 +368,8 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer(null, 'laminasview-layout');
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name, 'layout' => 'laminasview-layout2' ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name, 'layout' => 'laminasview-layout2']);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -389,8 +388,8 @@ class LaminasViewRendererTest extends TestCase
 
         $renderer = new LaminasViewRenderer(null, $layout);
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name]);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -408,8 +407,8 @@ class LaminasViewRendererTest extends TestCase
 
         $renderer = new LaminasViewRenderer(null, 'laminasview-layout');
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'laminasview';
-        $result = $renderer->render('laminasview', [ 'name' => $name, 'layout' => $layout ]);
+        $name   = 'laminasview';
+        $result = $renderer->render('laminasview', ['name' => $name, 'layout' => $layout]);
         $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
@@ -428,7 +427,7 @@ class LaminasViewRendererTest extends TestCase
         $renderer = new LaminasViewRenderer(null, $layout);
         $renderer->addPath(__DIR__ . '/TestAsset');
 
-        $name = 'laminasview';
+        $name     = 'laminasview';
         $rendered = $renderer->render('laminasview', [
             'layout' => false,
             'name'   => $name,
@@ -452,9 +451,8 @@ class LaminasViewRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $renderer->addDefaultParam(TemplateRendererInterface::TEMPLATE_ALL, 'layout', false);
 
-
-        $name = 'laminasview';
-        $rendered = $renderer->render('laminasview', [ 'name' => $name ]);
+        $name     = 'laminasview';
+        $rendered = $renderer->render('laminasview', ['name' => $name]);
 
         $expected = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $expected = str_replace('<?php echo $name ?>', $name, $expected);
@@ -495,12 +493,12 @@ class LaminasViewRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $name = 'LaminasView';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('laminasview');
+        $result  = $renderer->render('laminasview');
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $this->assertEquals($content, $result);
 
-        $result = $renderer->render('laminasview-2');
+        $result  = $renderer->render('laminasview-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview-2.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $this->assertEquals($content, $result);
@@ -510,22 +508,25 @@ class LaminasViewRendererTest extends TestCase
     {
         $renderer = new LaminasViewRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Laminas';
+        $name  = 'Laminas';
         $name2 = 'View';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
         $renderer->addDefaultParam('laminasview-2', 'name', $name2);
-        $result = $renderer->render('laminasview');
+        $result  = $renderer->render('laminasview');
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $this->assertEquals($content, $result);
 
-        $result = $renderer->render('laminasview-2');
+        $result  = $renderer->render('laminasview-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview-2.phtml');
         $content = str_replace('<?php echo $name ?>', $name2, $content);
         $this->assertEquals($content, $result);
     }
 
-    public function useArrayOrViewModel()
+    /**
+     * @psalm-return array<string, bool[]>
+     */
+    public function useArrayOrViewModel(): array
     {
         return [
             'array'      => [false],
@@ -535,21 +536,20 @@ class LaminasViewRendererTest extends TestCase
 
     /**
      * @dataProvider useArrayOrViewModel
-     *
      * @param bool $viewAsModel
      */
     public function testOverrideSharedParametersAtRender($viewAsModel)
     {
         $renderer = new LaminasViewRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Laminas';
+        $name  = 'Laminas';
         $name2 = 'View';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
 
         $viewModel = ['name' => $name2];
         $viewModel = $viewAsModel ? new ViewModel($viewModel) : $viewModel;
 
-        $result = $renderer->render('laminasview', $viewModel);
+        $result  = $renderer->render('laminasview', $viewModel);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', $name2, $content);
         $this->assertEquals($content, $result);
@@ -561,7 +561,7 @@ class LaminasViewRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
 
         $viewModel = new ViewModel(['name' => 'Laminas']);
-        $result = $renderer->render('laminasview', $viewModel);
+        $result    = $renderer->render('laminasview', $viewModel);
 
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview.phtml');
         $content = str_replace('<?php echo $name ?>', 'Laminas', $content);
@@ -570,7 +570,7 @@ class LaminasViewRendererTest extends TestCase
 
     public function testCanRenderWithChildViewModel()
     {
-        $path = __DIR__ . '/TestAsset';
+        $path     = __DIR__ . '/TestAsset';
         $renderer = new LaminasViewRenderer();
         $renderer->addPath($path);
 
@@ -623,11 +623,11 @@ class LaminasViewRendererTest extends TestCase
 
     public function testCanRenderWithCustomDefaultSuffix()
     {
-        $name = 'laminas-custom-suffix';
-        $suffix = 'pht';
+        $name     = 'laminas-custom-suffix';
+        $suffix   = 'pht';
         $renderer = new LaminasViewRenderer(null, null, $suffix);
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $result = $renderer->render('laminasview-custom-suffix', ['name' => $name]);
+        $result  = $renderer->render('laminasview-custom-suffix', ['name' => $name]);
         $content = file_get_contents(__DIR__ . '/TestAsset/laminasview-custom-suffix.' . $suffix);
         $content = str_replace('<?php echo $name ?>', $name, $content);
         $this->assertEquals($content, $result);

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -28,7 +28,7 @@ class ServerUrlHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->baseHelper = $this->createMock(BaseHelper::class);
-        $this->helper = new ServerUrlHelper($this->baseHelper);
+        $this->helper     = new ServerUrlHelper($this->baseHelper);
     }
 
     public function testInvocationProxiesToBaseHelper(): void

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -25,7 +25,7 @@ class UrlHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->baseHelper = $this->createMock(BaseHelper::class);
-        $this->helper = new UrlHelper($this->baseHelper);
+        $this->helper     = new UrlHelper($this->baseHelper);
     }
 
     public function testInvocationProxiesToBaseHelper(): void


### PR DESCRIPTION
This patch updates the component to laminas-coding-standard v2.1, and corrects issues flagged by the new standard rules.
