### PR TITLE
Removes stream wrapper functionality

### DIFF
--- a/src/NamespacedPathStackResolver.php
+++ b/src/NamespacedPathStackResolver.php
@@ -7,7 +7,6 @@ namespace Mezzio\LaminasView;
 use Laminas\View\Exception as ViewException;
 use Laminas\View\Renderer\RendererInterface;
 use Laminas\View\Resolver\TemplatePathStack;
-use Laminas\View\Stream;
 use SplFileInfo;
 use SplStack;
 use Traversable;
@@ -17,8 +16,6 @@ use function count;
 use function file_exists;
 use function get_class;
 use function gettype;
-use function in_array;
-use function ini_get;
 use function is_array;
 use function is_object;
 use function is_string;
@@ -26,8 +23,6 @@ use function iterator_to_array;
 use function pathinfo;
 use function preg_match;
 use function sprintf;
-use function stream_get_wrappers;
-use function stream_wrapper_register;
 use function substr;
 
 use const PATHINFO_EXTENSION;
@@ -58,14 +53,6 @@ class NamespacedPathStackResolver extends TemplatePathStack
      */
     public function __construct(?iterable $options = null)
     {
-        $this->useViewStream = (bool) ini_get('short_open_tag');
-        if ($this->useViewStream) {
-            if (! in_array('laminas.view', stream_get_wrappers())) {
-                /** @psalm-suppress DeprecatedClass */
-                stream_wrapper_register('laminas.view', Stream::class);
-            }
-        }
-
         if (null !== $options) {
             $this->setOptions($options);
         }
@@ -221,11 +208,6 @@ class NamespacedPathStackResolver extends TemplatePathStack
                     }
                 }
 
-                /** @psalm-suppress DeprecatedMethod */
-                if ($this->useStreamWrapper()) {
-                    // If using a stream wrapper, prepend the spec to the path
-                    $filePath = 'laminas.view://' . $filePath;
-                }
                 return $filePath;
             }
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes

### Description

Removes stream wrappers registered in the path stack template resolver - in v3 of laminas-view, it's been removed: https://github.com/laminas/laminas-view/pull/129