### PR TITLE
Remove Zend related service aliases and compatibility

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -52,13 +52,12 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/LaminasViewRendererFactory.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="5">
       <code>$config['layout'] ?? null</code>
       <code>$config['map'] ?? []</code>
       <code>$defaultSuffix</code>
       <code>$namespace</code>
       <code>$path</code>
-      <code>$renderer</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="5">
       <code>$config['default_suffix']</code>
@@ -67,7 +66,7 @@
       <code>$config['map']</code>
       <code>$config['templates']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$allPaths</code>
       <code>$config</code>
       <code>$config</code>
@@ -76,15 +75,7 @@
       <code>$namespace</code>
       <code>$path</code>
       <code>$paths</code>
-      <code>$renderer</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>HelperPluginManager</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>setResolver</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1"/>
   </file>
   <file src="src/NamespacedPathStackResolver.php">
     <ImplementedReturnTypeMismatch occurrences="2">

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -27,11 +27,6 @@ class ConfigProvider
         return [
             'aliases'   => [
                 TemplateRendererInterface::class => LaminasViewRenderer::class,
-
-                // Legacy Zend Framework aliases
-                'Zend\Expressive\Template\TemplateRendererInterface' => TemplateRendererInterface::class,
-                'Zend\View\HelperPluginManager'                      => HelperPluginManager::class,
-                'Zend\Expressive\ZendView\ZendViewRenderer'          => LaminasViewRenderer::class,
             ],
             'factories' => [
                 HelperPluginManager::class => HelperPluginManagerFactory::class,

--- a/src/LaminasViewRendererFactory.php
+++ b/src/LaminasViewRendererFactory.php
@@ -63,9 +63,7 @@ class LaminasViewRendererFactory
         // Create or retrieve the renderer from the container
         $renderer = $container->has(PhpRenderer::class)
             ? $container->get(PhpRenderer::class)
-            : ($container->has('Zend\View\Renderer\PhpRenderer')
-                ? $container->get('Zend\View\Renderer\PhpRenderer')
-                : new PhpRenderer());
+            : new PhpRenderer();
         $renderer->setResolver($resolver);
 
         // Inject helpers
@@ -103,40 +101,28 @@ class LaminasViewRendererFactory
         $helpers->setAlias('url', BaseUrlHelper::class);
         $helpers->setAlias('Url', BaseUrlHelper::class);
         $helpers->setFactory(BaseUrlHelper::class, function () use ($container) {
-            if (
-                ! $container->has(BaseUrlHelper::class)
-                && ! $container->has('Zend\Expressive\Helper\UrlHelper')
-            ) {
+            if (! $container->has(BaseUrlHelper::class)) {
                 throw new Exception\MissingHelperException(sprintf(
                     'An instance of %s is required in order to create the "url" view helper; not found',
                     BaseUrlHelper::class
                 ));
             }
-            return new UrlHelper(
-                $container->has(BaseUrlHelper::class)
-                    ? $container->get(BaseUrlHelper::class)
-                    : $container->get('Zend\Expressive\Helper\UrlHelper')
-            );
+
+            return new UrlHelper($container->get(BaseUrlHelper::class));
         });
 
         $helpers->setAlias('serverurl', BaseServerUrlHelper::class);
         $helpers->setAlias('serverUrl', BaseServerUrlHelper::class);
         $helpers->setAlias('ServerUrl', BaseServerUrlHelper::class);
         $helpers->setFactory(BaseServerUrlHelper::class, function () use ($container) {
-            if (
-                ! $container->has(BaseServerUrlHelper::class)
-                && ! $container->has('Zend\Expressive\Helper\ServerUrlHelper')
-            ) {
+            if (! $container->has(BaseServerUrlHelper::class)) {
                 throw new Exception\MissingHelperException(sprintf(
                     'An instance of %s is required in order to create the "url" view helper; not found',
                     BaseServerUrlHelper::class
                 ));
             }
-            return new ServerUrlHelper(
-                $container->has(BaseServerUrlHelper::class)
-                    ? $container->get(BaseServerUrlHelper::class)
-                    : $container->get('Zend\Expressive\Helper\ServerUrlHelper')
-            );
+
+            return new ServerUrlHelper($container->get(BaseServerUrlHelper::class));
         });
 
         $renderer->setHelperPluginManager($helpers);
@@ -146,10 +132,6 @@ class LaminasViewRendererFactory
     {
         if ($container->has(HelperPluginManager::class)) {
             return $container->get(HelperPluginManager::class);
-        }
-
-        if ($container->has('Zend\View\HelperPluginManager')) {
-            return $container->get('Zend\View\HelperPluginManager');
         }
 
         return new HelperPluginManager($container);

--- a/test/LaminasViewRendererFactoryTest.php
+++ b/test/LaminasViewRendererFactoryTest.php
@@ -126,14 +126,12 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testCallingFactoryWithNoConfigReturnsLaminasViewInstance(): LaminasViewRenderer
     {
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(never())
@@ -162,14 +160,12 @@ class LaminasViewRendererFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', true],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(self::once())
@@ -195,14 +191,12 @@ class LaminasViewRendererFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', true],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(self::once())
@@ -248,14 +242,12 @@ class LaminasViewRendererFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', true],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(self::once())
@@ -293,14 +285,12 @@ class LaminasViewRendererFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', true],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(self::once())
@@ -331,14 +321,12 @@ class LaminasViewRendererFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->expects(self::exactly(5))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', true],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $this->container->expects(self::once())
@@ -363,14 +351,12 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testInjectsCustomHelpersIntoHelperManager(): void
     {
-        $this->container->expects(self::atLeast(5))
+        $this->container->expects(self::atLeast(3))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
                 [Helper\UrlHelper::class, true],
                 [Helper\ServerUrlHelper::class, true],
             ]);
@@ -397,13 +383,12 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testWillUseHelperManagerFromContainer(): void
     {
-        $this->container->expects(self::exactly(4))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
                 [HelperPluginManager::class, true],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
             ]);
 
         $helpers = new HelperPluginManager($this->container);
@@ -424,14 +409,12 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testUrlAndServerUrlHelpersAreRegisteredWithTheExpectedAliases(): void
     {
-        $this->container->expects(self::atLeast(6))
+        $this->container->expects(self::atLeast(5))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
                 [HelperPluginManager::class, true],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, false],
-                ['Zend\View\Renderer\PhpRenderer', false],
                 [Helper\UrlHelper::class, true],
                 [Helper\ServerUrlHelper::class, true],
             ]);
@@ -469,12 +452,11 @@ class LaminasViewRendererFactoryTest extends TestCase
 
     public function testWillUseRendererFromContainer(): void
     {
-        $this->container->expects(self::exactly(4))
+        $this->container->expects(self::exactly(3))
             ->method('has')
             ->willReturnMap([
                 ['config', false],
                 [HelperPluginManager::class, false],
-                ['Zend\View\HelperPluginManager', false],
                 [PhpRenderer::class, true],
             ]);
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no - at least I don't see it that way!
| QA            | yes

### Description

`laminas-view` has been required at `^2.20` for a long time now. There is of course no equivalent version for `zend-view` and it's not feasible that this package could co-exist with any of the referenced legacy class-strings, but adds a conflict to be on the safe side.