### PR TITLE
Support `psr/container:^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "mezzio/mezzio-helpers": "^5.15.0",
         "mezzio/mezzio-router": "^3.16.1",
         "mezzio/mezzio-template": "^2.8.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0.1 || ^2.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ede2d34bc1727d96108acbebd7e4e038",
+    "content-hash": "90403ed65896c0ea3f321618efdf3f8d",
     "packages": [
         {
             "name": "fig/http-message-util",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Adding support for `psr/container:^2.0` in composer.json (its basically the same as 1.0 but with return types)