### PR TITLE
Updates GitHub workflow for documentation build

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,8 +3,7 @@ name: docs-build
 on:
   release:
     types: [published]
-  repository_dispatch:
-    types: docs-build
+  workflow_dispatch:
 
 jobs:
   build-deploy:
@@ -13,5 +12,5 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          "DOCS_DEPLOY_KEY": ${{ secrets.DOCS_DEPLOY_KEY }}
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `DOCS_DEPLOY_KEY` is the legacy key and must be replaced:

```bash
# check values
remote_repo=""
if [ -n "${DEPLOY_TOKEN}" ]; then
    remote_repo_setup remote_repo "${DEPLOY_TOKEN}"
else
    if [ -n "${DOCS_DEPLOY_KEY}" ]; then
        remote_repo_setup_legacy remote_repo "${DOCS_DEPLOY_KEY}"
    else
        print_error "Neither DEPLOY_TOKEN nor DOCS_DEPLOY_KEY found; please provide one or the other in your workflow env"
        kill -s KILL $TOP_PID
    fi
fi
```

https://github.com/laminas/documentation-theme/blob/c9c95a899460735dc06ccff05ec47d1c4f95e8ba/github-actions/docs/entrypoint.sh#L64-L75